### PR TITLE
ambient bit added back to account for walled pointcloud in viewer

### DIFF
--- a/ros/src/publisher_nodelet.cpp
+++ b/ros/src/publisher_nodelet.cpp
@@ -100,7 +100,7 @@ void PublisherNodelet::onInit() {
   // Check for which points should be included based on params for flag bits
   {
     bool include = true;
-    include_flag_ = 0;
+
     ROS_INFO("============= Point Flag Parameters =============\n");
 
     private_node_handle_.param("include_saturated_points", include, true);
@@ -128,9 +128,6 @@ void PublisherNodelet::onInit() {
     ROS_INFO("Including Blocked points: %s\n", include ? "true" : "false");
 
     ROS_INFO("=================================================\n");
-
-    include_flag_ |= CEPTON_POINT_BLOOMING | CEPTON_POINT_FRAME_PARITY |
-                     CEPTON_POINT_FRAME_BOUNDARY;
   }
 
   // Assign publisher for info
@@ -275,7 +272,7 @@ void PublisherNodelet::publish_points(CeptonSensorHandle handle,
 
       // If point has flags that should not be included (specified by the
       // include_flag), continue
-      if ((~include_flag_ & static_cast<uint8_t>(p.flags & 0x00ff)) != 0) continue;
+      if ((~include_flag_ & p.flags) != 0) continue;
 
       // Convert the units to meters (SDK unit is 1.0 / 65536.0)
       float x = static_cast<float>(p.x) / 65536.0;

--- a/ros/src/publisher_nodelet.hpp
+++ b/ros/src/publisher_nodelet.hpp
@@ -81,7 +81,16 @@ class PublisherNodelet : public nodelet::Nodelet {
    * Flag that is populated by settings, telling the nodelet which points
    * should be included in the output messages
    */
-  uint8_t include_flag_;
+  // uint8_t include_flag_;
+  /* Based on config params, bit is flipped as 1 for point flags that should be
+  included, while 0 if excluded The pre-included flags are "ignored," either
+  because it is for internal use only (hence no config to include them) or
+  because it is deprecated.
+
+  Ambient point information exists for all points, the corresponding flag bit
+  for ambient point is (1 << 15), hence the inclusion to include_flag_*/
+  uint16_t include_flag_ = CEPTON_POINT_BLOOMING | CEPTON_POINT_FRAME_PARITY |
+                           CEPTON_POINT_FRAME_BOUNDARY | (1 << 15);
   CeptonReplayHandle replay_handle_{0};
 
   /** If set to true, the nodelet will advertise topics by sensor handle */


### PR DESCRIPTION
Jiaming and Ryan did this, to restore the ambient mode bit back into ros1 driver, making it consistent with ros2 driver and hopefully fixes Nissan's newest issue with "walled" pointcloud in rviz
