### PR TITLE
Update ros driver pointfield

### DIFF
--- a/ros/include/cepton_ros/cepton_ros.hpp
+++ b/ros/include/cepton_ros/cepton_ros.hpp
@@ -23,10 +23,10 @@ struct Point {
   float z;
   float intensity;
 #ifdef WITH_TS_CH_F
-  uint8_t relative_timestamp;
-  uint8_t flags;
-  uint8_t channel_id;
-  uint8_t valid;
+  uint16_t relative_timestamp;
+  uint16_t flags;
+  uint16_t channel_id;
+  uint16_t valid;
 #endif
 #ifdef WITH_POLAR
   float azimuth;
@@ -45,10 +45,10 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(cepton_ros::Point,
     (float, z, z)
     (float, intensity, intensity)
     #ifdef WITH_TS_CH_F
-    (std::uint8_t, relative_timestamp, relative_timestamp)
-    (std::uint8_t, flags, flags)
-    (std::uint8_t, channel_id, channel_id)
-    (std::uint8_t, valid, valid)
+    (std::uint16_t, relative_timestamp, relative_timestamp)
+    (std::uint16_t, flags, flags)
+    (std::uint16_t, channel_id, channel_id)
+    (std::uint16_t, valid, valid)
     #endif
     #ifdef WITH_POLAR
     (float, azimuth, azimuth)


### PR DESCRIPTION
Hi Cepton team,

Nissan Robo-taxi team reported that ROS1 driver doesn't distinguish all channels of Vista Ultra.
Separated regions are displayed with same color(=channel_id). (see fig.1)
It seems that the value of channel_id overflows and wraps back to 0 at a certain point.

I changed definition of channel_id from uint_8 to uint16, and it works properly now (see fig.2).

Please review this modification and approve the pull request.

<img width="1187" height="753" alt="fig1" src="https://github.com/user-attachments/assets/3effe9cd-8d48-4f5e-85bd-5a20c8f034f4" />
<img width="1183" height="751" alt="fig2" src="https://github.com/user-attachments/assets/c45205b6-20eb-453e-a80e-4bc05ad2b455" />
