### PR TITLE
Add basic usage instructions to README.md of ROS2

### DIFF
--- a/ros/README.md
+++ b/ros/README.md
@@ -1,3 +1,41 @@
+# Prerequisites
+### Supported Platforms
+- Ubuntu 20.04 LTS `amd64`/`arm64` + ROS Noetic Ninjemys
+
+# Basic usage
+### Build
+```bash
+# Configure your terminal's environment
+source /opt/ros/noetic/setup.bash
+
+# Set up a catkin workspace and symlink the repo
+mkdir -p catkin_ws/src
+cd catkin_ws/src
+ln -s $(pwd)/../../ros/ros
+
+cd ..
+catkin_make
+```
+
+### Run
+```bash
+# This is needed for each terminal you open
+source /opt/ros/noetic/setup.bash
+source catkin_ws/devel/setup.bash
+
+# Launch the nodelet manager
+# This is needed before launching the publisher
+roslaunch cepton_ros manager.launch
+
+# On another terminal, launch CeptonPublisher
+roslaunch cepton_ros publisher.launch
+
+# View the point cloud on RViz
+# On another terminal, run
+rviz -d ros/cepton_ros.rviz
+```
+
+
 # Cepton ROS Publisher Nodelet Configuration Guide
 
 This guide covers all configuration options available for the Cepton ROS Publisher Nodelet based on the implementation in `publisher_nodelet.cpp`.

--- a/ros2/README.md
+++ b/ros2/README.md
@@ -1,5 +1,11 @@
-# Basic Usage
-#### Build
+# Prerequisites
+### Supported Platforms
+- Ubuntu 20.04 LTS `amd64`/`arm64` + ROS 2 Galactic Geochelone
+- Ubuntu 22.04 LTS `amd64`/`arm64` + ROS 2 Humble Hawksbill
+- Ubuntu 24.04 LTS `amd64`/`arm64` + ROS 2 Jazzy Jalisco
+
+# Basic usage
+### Build
 ```bash
 # Configure your terminal's environment
 # Change the distro name if needed
@@ -9,7 +15,7 @@ cd ros/ros2
 colcon build
 ```
 
-#### Run
+### Run
 ```bash
 # This is needed for each terminal you open
 source /opt/ros/jazzy/setup.bash

--- a/ros2/README.md
+++ b/ros2/README.md
@@ -1,4 +1,30 @@
-# Cepton ROS Publisher Configuration Guide
+# Basic Usage
+#### Build
+```bash
+# Configure your terminal's environment
+# Change the distro name if needed
+source /opt/ros/jazzy/setup.bash
+
+cd ros/ros2
+colcon build
+```
+
+#### Run
+```bash
+# This is needed for each terminal you open
+source /opt/ros/jazzy/setup.bash
+source ros/ros2/install/setup.bash
+
+# Launch CeptonPublisher with default settings
+ros2 run cepton_publisher cepton_publisher_node
+
+# View the point cloud on RViz2
+# On another terminal, run
+rviz2 rviz2 -d ros/cepton_ros2.rviz
+```
+
+
+# CeptonPublisher Configuration Guide
 
 This guide covers all configuration options available for the Cepton ROS Publisher based on the implementation in `cepton_publisher.cpp`.
 


### PR DESCRIPTION
Updated README.md to include basic usage instructions for building and running the CeptonPublisher.